### PR TITLE
Allow for swagger document to be passed in custom.documentation

### DIFF
--- a/src/swagger.js
+++ b/src/swagger.js
@@ -1,0 +1,50 @@
+'use strict'
+
+function replaceSwaggerRefs (swagger) {
+  function replaceRefs (obj) {
+    if (!obj) {
+      return
+    }
+    for (let key of Object.keys(obj)) {
+      if (key === '$ref') {
+        let match
+        if (match = /#\/definitions\/([\-\w]+)/.exec(obj[key])) {
+          obj[key] = '{{model: ' + match[1] + '}}'
+        }
+      } else if (typeof obj[key] === 'object') {
+        replaceRefs(obj[key])
+      }
+    }
+  }
+
+  replaceRefs(swagger)
+}
+
+function extractModelDefinition(param, models) {
+  // if the schema is just a $ref, set it to that value
+  // otherwise create a model to handle this response
+  if (param.schema['$ref']) {
+    let match
+    if (match = /#\/definitions\/([\-\w]+)/.exec(param.schema['$ref'])) {
+      return match[1];
+    }
+  } else {
+    replaceSwaggerRefs(param.schema)
+    models.push({
+      name: param.name,
+      description: param.description,
+      contentType: 'application/json',
+      schema: param.schema
+    })
+    return param.name;
+  }
+}
+
+module.exports = {
+  replaceSwaggerDefinitions: function replaceSwaggerDefinitions (swagger) {
+    return replaceSwaggerRefs(swagger)
+  },
+  extractModel: function extractModel(param, models) {
+    return extractModelDefinition(param, models)
+  }
+}


### PR DESCRIPTION
Happy to clean this up a bit, wanted to get an idea of how open to this you were.

- You can now import swagger directly into custom.documentation

```
custom:
  documentation: ${file(./swagger.yml)}
```

- It will read the documentation and make the necessary elements for adding into the cloudformation. Reusing the existing code from this plugin.
- Support all param types (header, query, body) and response models
- If a request body/response body is provided inline in the swagger it extracts it and creates a new model.
- I have one observation, if a description aren't provided for any models the creation of documentation parts fails and serverless throws and error at the end (stack is still created)

100% line coverage 