### PR TITLE
Dynamic custom config generation bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,8 @@ class ServerlessAWSDocumentation {
   }
 
   beforeDeploy() {
+    // reinitialize customVars, to handle dynamic config generation
+    this.customVars = this.serverless.variables.service.custom;
     if (!(this.customVars && this.customVars.documentation)) return;
 
     this.cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;


### PR DESCRIPTION
In a case, that documentation variable added dynamically to custom, by `generate.js` script, `this.customVars` remains uninitialized, since generate.js runs after the plugin constructed. That causes an immediate return at ` if (!(this.customVars && this.customVars.documentation)) return;` check.

Reinitializing `this.customVars`in beforeDeploy() solves the problem