### PR TITLE
Corrected parameter for downloadDocumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ See the Serverless documentation for more information on [resource naming](https
 
 ### Download documentation from AWS API Gateway
 
-To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFile=filename.ext`.
+To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFileName=filename.ext`.
 For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json. 
 
 ## Contribution


### PR DESCRIPTION
The downloadDocumentation command requires the `--outputFileName=` parameter instead of `--outputFile=`.