### PR TITLE
Fixed extract-rest-api-id.js issue when multiple chunks

### DIFF
--- a/example/extract-rest-api-id.js
+++ b/example/extract-rest-api-id.js
@@ -22,7 +22,7 @@ stdin.on('data', function (chunk) {
 })
 
 stdin.on('end', function () {
-  let inputJSON = inputChunks.join()
+  let inputJSON = inputChunks.join('')
   let parsedData = JSON.parse(inputJSON)
   parsedData.items.forEach(function (curr) {
     if (curr.name === targetRestApiName) {


### PR DESCRIPTION
Added empty string on chunks join to avoid default ',' (comma) character used by JS.