### PR TITLE
Adding the ability to specify an extensions type for output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ See the Serverless documentation for more information on [resource naming](https
 ### Download documentation from AWS API Gateway
 
 To download the deployed documentation you just need to use `serverless downloadDocumentation --outputFileName=filename.ext`.
-For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json. 
+For `yml` or `yaml` extensions application/yaml content will be downloaded from AWS. In any other case - application/json.
+Optional argument --extensions ['integrations', 'apigateway', 'authorizers', 'postman']. Defaults to 'integrations'.
 
 ## Contribution
 

--- a/src/downloadDocumentation.js
+++ b/src/downloadDocumentation.js
@@ -9,6 +9,9 @@ module.exports = {
         stageName: this.serverless.service.provider.stage,
         restApiId: restApiId,
         exportType: 'swagger',
+        parameters: {
+          extensions: extensionType(this.options.extensions),
+        },
         accepts: createAWSContentType(this.options.outputFileName),
       });
     }).then((response) => {
@@ -43,5 +46,15 @@ function createAWSContentType(outputFileName) {
   }
 
   return awsContentType;
+}
+
+function extensionType(extensionArg) {
+  const possibleExtensions = ['integrations', 'apigateway', 'authorizers', 'postman'];
+
+  if (possibleExtensions.includes(extensionArg)) {
+    return extensionArg;
+  } else {
+    return 'integrations';
+  }
 }
 

--- a/src/downloadDocumentation.spec.js
+++ b/src/downloadDocumentation.spec.js
@@ -47,6 +47,9 @@ describe('ServerlessAWSDocumentation', function () {
           stageName: 'testStage',
           restApiId: 'testRestApiId',
           exportType: 'swagger',
+          parameters: {
+            extensions: 'integrations',
+          },
           accepts: 'application/json',
         });
         expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.txt', 'some body');
@@ -71,6 +74,37 @@ describe('ServerlessAWSDocumentation', function () {
           stageName: 'testStage',
           restApiId: 'testRestApiId',
           exportType: 'swagger',
+          parameters: {
+            extensions: 'integrations',
+          },
+          accepts: 'application/yaml',
+        });
+        expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.yml', 'some body');
+
+        done();
+      });
+    });
+
+    it('should successfully download documentation, yaml extension, using an extensions argument', (done) => {
+      objectUnderTest.options = {
+        outputFileName: 'test.yml',
+        extensions: 'apigateway',
+      };
+      objectUnderTest._getRestApiId = () => {
+        return Promise.resolve('testRestApiId')
+      };
+
+      objectUnderTest.serverless.providers.aws.request.and.returnValue(Promise.resolve({
+        body: 'some body',
+      }));
+      return objectUnderTest.downloadDocumentation().then(() => {
+        expect(objectUnderTest.serverless.providers.aws.request).toHaveBeenCalledWith('APIGateway', 'getExport', {
+          stageName: 'testStage',
+          restApiId: 'testRestApiId',
+          exportType: 'swagger',
+          parameters: {
+            extensions: 'apigateway',
+          },
           accepts: 'application/yaml',
         });
         expect(objectUnderTest.fs.writeFileSync).toHaveBeenCalledWith('test.yml', 'some body');

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,10 @@ class ServerlessAWSDocumentation {
             ],
             options: {
                 outputFileName: {
-                    required: true,
+                  required: true,
+                },
+                extensions: {
+                    required: false,
                 },
             },
         }


### PR DESCRIPTION
We had a use-case to download a different extension type. This pull request adds the ability to specify an optional argument of extensions while defaulting to the current default of 'integrations' if no argument is given.