### PR TITLE
Re-check custom section to allow file variable resolution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,8 @@ class ServerlessAWSDocumentation {
   }
 
   beforeDeploy() {
+    this.customVars = this.serverless.variables.service.custom;
+    
     if (!(this.customVars && this.customVars.documentation)) return;
 
     this.cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -89,6 +89,7 @@ describe('ServerlessAWSDocumentation', function () {
     });
 
     it('shouldn\'t do anything if there are no custom variables', function () {
+      delete this.serverlessMock.variables.service.custom;
       delete this.plugin.customVars;
       this.plugin.beforeDeploy();
       expect(this.serverlessMock.service.getAllFunctions).not.toHaveBeenCalled();


### PR DESCRIPTION
Re-checking the custom section after variable replacement/resolution is performed, so that any variable replacements in the custom section that might lead to the documentation object being present can occur.