### PR TITLE
Skip all Documentation Parts overwriting in case of shared API Gateway usage.

### DIFF
--- a/src/documentation.js
+++ b/src/documentation.js
@@ -92,8 +92,13 @@ module.exports = function() {
         }
       });
     },
+    
+    _isSharedApi: function _isSharedApi(){
+      return !!this.serverless.service.provider.apiGateway.restApiId;
+    },
 
     _updateDocumentation: function _updateDocumentation() {
+      const serverlessServicePropertyKey = 'serverless-service';
       const aws = this.serverless.providers.aws;
       return aws.request('APIGateway', 'getDocumentationVersion', {
         restApiId: this.restApiId,
@@ -116,7 +121,14 @@ module.exports = function() {
             limit: 9999,
           })
         )
-        .then(results => results.items.map(
+        .then(results => results.items.filter(part => {
+            if (this._isSharedApi()){
+              console.log('---- filtering docpart with properties', part.properties);
+              return JSON.parse(part.properties)[serverlessServicePropertyKey] === this.serverless.service.service;
+            }
+            return true;
+          })          
+          .map(
           part => aws.request('APIGateway', 'deleteDocumentationPart', {
             documentationPartId: part.id,
             restApiId: this.restApiId,
@@ -125,7 +137,11 @@ module.exports = function() {
         .then(promises => Promise.all(promises))
         .then(() => this.documentationParts.reduce((promise, part) => {
           return promise.then(() => {
+            if (this._isSharedApi()) {
+              part.properties[serverlessServicePropertyKey] = this.serverless.service.service;
+            }
             part.properties = JSON.stringify(part.properties);
+            console.log('---- sending to createDocumentationPart', part.properties);            
             return aws.request('APIGateway', 'createDocumentationPart', part);
           });
         }, Promise.resolve()))

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -94,7 +94,7 @@ module.exports = function() {
     },
     
     _isSharedApi: function _isSharedApi(){
-      return !!this.serverless.service.provider.apiGateway.restApiId;
+      return this.serverless.service.provider.apiGateway ? !!this.serverless.service.provider.apiGateway.restApiId : false;
     },
 
     _updateDocumentation: function _updateDocumentation() {

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -123,7 +123,6 @@ module.exports = function() {
         )
         .then(results => results.items.filter(part => {
             if (this._isSharedApi()){
-              console.log('---- filtering docpart with properties', part.properties);
               return JSON.parse(part.properties)[serverlessServicePropertyKey] === this.serverless.service.service;
             }
             return true;
@@ -141,7 +140,6 @@ module.exports = function() {
               part.properties[serverlessServicePropertyKey] = this.serverless.service.service;
             }
             part.properties = JSON.stringify(part.properties);
-            console.log('---- sending to createDocumentationPart', part.properties);            
             return aws.request('APIGateway', 'createDocumentationPart', part);
           });
         }, Promise.resolve()))


### PR DESCRIPTION
tackling this problem: https://github.com/deliveryhero/serverless-aws-documentation/issues/106.

As of today plugin removes _all_ doc-parts before deploying modified changed documentation. While this approach works ok in majority cases, it fails when API Gateway instance is reused by many sls deployments (and this scheme is more frequent approach as developers build more complicated APIs).
This PR introduce a piece of functionality which helped me to keep up with API documentation functionality having roughly dozen individual serverless.yml deploying under one API Gateway.

New function _isSharedApi() uses serverless.yml information to return if API is being deployed is in standalone mode (which are any deployment so far, since plugin correctly refreshed Documentation for that cases) or uses (shares) pre-existing API Gateway per https://serverless.com/framework/docs/providers/aws/events/apigateway#share-api-gateway-and-api-resources.

If deploying API is standalone, execution logic stays the same, i.e. all doc-parts removed and than recreated from deployment.
If deploying API is shared, only those doc-parts which belongs to current service (new property 'serverless-service' saved with each doc-part) removed and recreated. Thus, all other doc-parts, belonging to main service, or other dependent services are left untouched.