### PR TITLE
Handle null values in object check

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -26,7 +26,7 @@ function replaceModelRefs(restApiId, cfModel) {
                     }
                     cfModel.DependsOn.add(match[1]+'Model');
                 }
-            } else if (typeof obj[key] === 'object') {
+            } else if (typeof obj[key] === 'object' && obj[key] !== null) {
                 replaceRefs(obj[key]);
             }
         }

--- a/src/models.spec.js
+++ b/src/models.spec.js
@@ -145,5 +145,27 @@ describe('ServerlessAWSDocumentation', function() {
             });
         });
 
+        it('should not crash with null values', () => {
+            let modelInput = {
+                contentType: 'application/json',
+                name: 'TestModel',
+                schema: {
+                    type: 'object',
+                    properties: {
+                        prop: {
+                            enum: ['test',  null],
+                            default: null
+                        }
+                    }
+                }
+            };
+
+            let modelExecution = function() {
+                objectUnderTest.createCfModel({
+                    Ref: 'ApiGatewayRestApi',
+                })(modelInput);
+            }
+            expect(modelExecution).not.toThrow();
+        });
     });
 })


### PR DESCRIPTION
In javascript null is object and it is valid value in schemas and for example as enumeration value.
https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values

This will fix issue that the plugin crashes when there is null value present in schema.

