### PR TITLE
fix: Add check if model dependency is string in order to use !ImportValue

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -63,7 +63,9 @@ module.exports = {
 
   addModelDependencies: function addModelDependencies(models, resource) {
     Object.keys(models).forEach(contentType => {
-      resource.DependsOn.add(`${models[contentType]}Model`);
+      if (typeof models[contentType] === 'string') {
+        resource.DependsOn.add(`${models[contentType]}Model`);
+      }
     });
   },
 


### PR DESCRIPTION
When using a shared API Gateway, there are times we want to share existing models. One option is to use Cloud formation cross stack reference. So I create the model and declare the Output in the main api gateway, and in the service I want to reference it, I use:

`responseModels:
          application/json: !ImportValue MyExistingResponseModel
`

The problem with this approach is that when using the !ImportValue, instead of a string, this model will become an object like this:
`
{ 'Fn::ImportValue': 'MyExistingResponseModel' }
`
When adding the model dependency to Cloud Formation, the function will add it like this [object Object]Model and return an error.

Since this model already exists, so we don't need to add it to the **DependsOn** property. Assuming that whenever we use !ImportValue, it will generate an object, we can add a check to the **addModelDependencies** function to only add it when it is a string.